### PR TITLE
(feat) Added CNAME.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+ironframework.io


### PR DESCRIPTION
This allows redirection from the apex domain, ironframework.io.
