### PR TITLE
Fixed some small formatting issues and a typo.

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,10 +194,10 @@ fn main() {
         <div class="content-box">  
           <h2 id="mixins">Mixins</h2>
           <p>To provide additional APIs for the <code>Request</code> and <code>Response</code> objects,
-          Iron utilizes mixin traits which add additional methods to the </code>Request</p> and <code>Response</code>.
+          Iron utilizes mixin traits which add additional methods to the <code>Request</code> and <code>Response</code> objects.
           To get access to these methods you must bring their associated traits into scope by
           <code>use</code>ing them.</p>
-          <p>Iron comes bundles with a few mixins for <code>Request</code> and <code>Response</code> for extremely
+          <p>Iron comes bundled with a few mixins for <code>Request</code> and <code>Response</code> for extremely
           common methods that are comparatively annoying to work with otherwise, such as
           getting the uri of the request or serving files with the correct MIME type.</p>
         </div>  <!-- /content-box -->


### PR DESCRIPTION
I found a couple of small typos on the http://ironframework.io/ page that caused the "Mixins" section to look weird.

The two main things I changed were these:
- Fixed a malformed `<code></code>` tag
- Changed the typo "bundles" to "bundled".
