### PR TITLE
Make some of the examples work

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,19 +62,21 @@
     <br><br>
     <div class="row hidden-xs example-code">
 <pre><code class="lang-rust">  
+extern crate http;
 extern crate iron;
-use std::io::net::ip::Ipv4Addr;
-use iron::{Iron, Server, Chain, Request, Response, Alloy, Status, Continue, FromFn};
 
-fn hello_world(_: &amp;mut Request, res: &amp;mut Response, _: &amp;mut Alloy) -&gt; Status {
-    res.write(b&quot;Hello World!&quot;);
-    Continue
+use std::io::net::ip::Ipv4Addr;
+use iron::{Iron, Chain, Alloy, Request, Response, Server, Status, Unwind, FromFn};
+
+fn hello_world(_req: &amp;mut Request, res: &amp;mut Response, _alloy: &amp;mut Alloy) -&gt; Status {
+    let _ = res.serve(::http::status::Ok, "Hello, world!");
+    Unwind
 }
 
 fn main() {
-  let mut server: Server = Iron::new();
-  server.chain.link(FromFn::new(hello_world));
-  server.listen(Ipv4Addr(127, 0, 0, 1), 3000);
+    let mut server: Server = Iron::new();
+    server.chain.link(FromFn::new(hello_world));
+    server.listen(Ipv4Addr(127, 0, 0, 1), 3000);
 }
 </code></pre>
     </div><!-- /row -->
@@ -133,27 +135,48 @@ pub trait Middleware {
           <p>Here is an example that integrates both:</p>
           
 <pre><code class="lang-rust">
+extern crate iron;
+extern crate time;
+
+use std::io::net::ip::Ipv4Addr;
+use iron::{Iron, Chain, Request, Response,
+           Middleware, Alloy, Server, Status,
+           Continue, Unwind, FromFn};
+
+use time::precise_time_ns;
+
 #[deriving(Clone)]
-struct ResponseTime { entry: u64 };
+struct ResponseTime {
+    entry: u64
+}
+
+impl ResponseTime { fn new() -> ResponseTime { ResponseTime { entry: 0u64 } } }
 
 impl Middleware for ResponseTime {
-    fn enter(&amp;mut self, _: &amp;mut Request, _: &amp;mut Response, _: &amp;mut Alloy) -&gt; Status {
-        self.entry = time::now(); Continue
+    fn enter(&amp;mut self, _req: &mut Request, _res: &amp;mut Response, _al: &amp;mut Alloy) -&gt; Status {
+        self.entry = precise_time_ns();
+        Continue
     }
-    fn exit(&amp;mut self, _: &amp;mut Request, _: &amp;mut Response, _: &amp;mut Alloy) -&gt; Status {
-        println!(&quot;Response took: {} ms&quot;, time::now() - self.entry);
+
+    fn exit(&amp;mut self, _req: &mut Request, _res: &amp;mut Response, _al: &amp;mut Alloy) -&gt; Status {
+        let delta = precise_time_ns() - self.entry;
+        println!("Request took: {} ms", (delta as f64) / 100000.0);
+        Continue
     }
 }
 
-fn hello_world(_: &amp;mut Request, res: &amp;mut Response, _: &amp;mut Alloy) -&gt; Status {
-    res.write(b&quot;Hello World!&quot;);
-    Continue
-}
+fn stop(_req: &amp;mut Request, _: &amp;mut Response, _: &amp;mut Alloy) -&gt; Status { Unwind }
 
 fn main() {
-    let mut server: ServerT = Iron::new();
-    server.chain.link(ResponseTime { entry: 0u });
-    server.chain.link(FromFn::new(hello_world));
+    let mut server: Server = Iron::new();
+
+    // This adds the ResponseTime middleware so that
+    // all requests and responses are passed through it.
+    server.chain.link(ResponseTime::new());
+    server.chain.link(FromFn::new(stop));
+
+    // Start the server on localhost:3000
+    server.listen(Ipv4Addr(127, 0, 0, 1), 3000);
 }
 </code></pre>
         </div>  <!-- /content-box -->


### PR DESCRIPTION
I am a complete rust noob, so these changes probably suck, but I wanted to play with iron and most of the code examples are broken, which seems like an issue. I took at shot at making them work.

I wanted to update the one that uses BodyParser too, and got as far as this, by hacking at the (also broken) example from that crate, and got as far as this:

``` rust
extern crate http;
extern crate iron;
extern crate bodyparser;
use iron::{Iron, Server, Chain, Request, Response, Alloy, FromFn, Status, Unwind};
use bodyparser::{BodyParser, Parsed};


fn log_json(_: &mut Request, _: &mut Response, alloy: &mut Alloy) -> Status {
    let json = alloy.find::<Parsed>();
    match json {
        Some(&Parsed(ref parsed)) => println!("{}", parsed),
        None => (),
    }
    Unwind
}

fn main() {
    let mut server: Server = Iron::new();
    server.chain.link(BodyParser::new()); // Add middleware to the server's stack
    server.chain.link(FromFn::new(log_json));
    server.listen(::std::io::net::ip::Ipv4Addr(127, 0, 0, 1), 3000);
}
```

However, I really wanted to make that code to something more like

``` rust
fn log_json(_: &mut Request, res: &mut Response, alloy: &mut Alloy) -> Status {
    let json = alloy.find::<Parsed>();
    match json {
        Some(&Parsed(ref parsed)) => res.serve(::http::status::Ok, format!("hello, {}", parsed.name)),
        None => res.serve(::http::status::BadRequest, format!("blah...")),
    }
    Unwind
}
```

that took me down a road of learning about `serialize::json` which is still over my head and I can't figure out how to get `parsed` into my struct and... But an example that showed how to get access to the properties of the json object would let me start building useful things much more quickly. Probably an issue for iron/bodyparser I guess.
