### PR TITLE
(feat) Add links to example repos.

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,10 +28,6 @@
           </a>
         </div>
         <div class="collapse navbar-collapse">
-          <!-- <ul class="nav navbar-nav">
-            <li class="active"><a href="#">Docs</a></li>
-            <li><a href="#contact">Other</a></li>
-          </ul> -->
           <ul class="nav navbar-nav navbar-right">
             <li class="doc-note">Our docs are served with Iron!</li>
             <li class="doc-link"><a href="http://docs.ironframework.io/">Docs</a></li>
@@ -102,7 +98,24 @@ fn main() {
           <p>To quickly get started creating Iron applications, you should use
           <a target="_blank" href="https://github.com/iron/core">Iron-Core</a>, which bundles several common
           middleware, including Routing, Body Parsing, Cookies, and Logging.</p>
+          <!-- TODO: replace with #example section once iron/example is built -->
+          <p>If you're looking for an example in the wild, check out our
+          <a target="_blank" href="https://github.com/iron/iron-doc">docs server</a>.
+          </p>
         </div>
+
+        <!-- TODO: build out iron/example
+        <div class="content-box">
+          <h2 id="example">Examples</h2>
+          <p>Along with examples in the <code>/examples</code> folder of every repo,
+          <a target="_blank" href="http://example.ironframework.io">example.ironframework.io</a>
+          is maintained from  the <a target="_blank" href="https://github.com/iron/example">official example repo</a>
+          as an example of Iron in action.</p>
+          <p>The documentation at <a target="_blank" href="http://docs.ironframework.io">docs.ironframework.io</a>
+          is also served using Iron, using the source at
+          <a target="_blank" href="https://github.com/iron/iron-doc">iron/iron-doc</a>.</p>
+        </div>
+        -->
 
         <div class="content-box">
           <h2 id="iron-new-">Iron::new()</h2>


### PR DESCRIPTION
@reem, what do you think of this? I liked @mk270's idea, and he's already started building out an examples repo.

I commented out a potential examples section.

Importantly, though, this links to the docs' server code, as requested in https://github.com/iron/iron-doc/issues/8. I need to update that code today as well (and refresh the outdated docs).
