### PR TITLE
Remove unused crate from hello_world example

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,6 @@
     <br><br>
     <div class="row hidden-xs example-code">
 <pre><code class="lang-rust">  
-extern crate http;
 extern crate iron;
 
 use std::io::net::ip::Ipv4Addr;


### PR DESCRIPTION
The example seems to run fine wihout `extern crate http`.
