### PR TITLE
change println order

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,9 +73,9 @@ fn main() {
     fn hello_world(_: &amp;mut Request) -> IronResult&lt;Response&gt; {
         Ok(Response::with((status::Ok, "Hello World!")))
     }
-
-    Iron::new(hello_world).http("localhost:3000").unwrap();
+    
     println!("On 3000");
+    Iron::new(hello_world).http("localhost:3000").unwrap();
 }
 
 </code></pre>


### PR DESCRIPTION
The example server never prints the current port because it is called before the server starts.