### PR TITLE
(fix) update example to correctly display listening message

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,8 +74,11 @@ fn main() {
         Ok(Response::with((status::Ok, "Hello World!")))
     }
 
-    Iron::new(hello_world).http("localhost:3000").unwrap();
-    println!("On 3000");
+    let result = Iron::new(hello_world).http("localhost:3000");
+    if result.is_ok() {
+        println!("Listening on http://localhost:3000/");
+    }
+    result.unwrap();
 }
 
 </code></pre>


### PR DESCRIPTION
Due to some issue between the result Drop impl joining the server thread,
the unwrap() call blocks. This patch moves the unwrap() to print the port first.

cf. https://github.com/brson/httptest#1-preparing-to-serve-some-json