### PR TITLE
Restrict wildcard version to 0.4.* on landing

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@ fn main() {
           <p>Iron tracks Rust nightly, which you can install <a target="_blank" href="http://www.rust-lang.org/">here</a>.</p>
           <p>To get Iron itself, just add it your project's <code>Cargo.toml</code>.
 <pre><code class="lang-toml">[dependencies]
-iron = "*"</code></pre>
+iron = "0.4.*"</code></pre>
           </p>
         </div>
 


### PR DESCRIPTION
Use of wildcard (*) version is not a good idea so lets not promote it on the start page.