### PR TITLE
remove Rust nightly notice

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@ fn main() {
 
         <div class="content-box">
           <h2 id="installation">Installation</h2>
-          <p>Iron tracks Rust nightly, which you can install <a target="_blank" href="http://www.rust-lang.org/">here</a>.</p>
+          <p>Iron works on Rust stable, which you can install <a target="_blank" href="http://www.rust-lang.org/">here</a>.</p>
           <p>To get Iron itself, just add it your project's <code>Cargo.toml</code>.
 <pre><code class="lang-toml">[dependencies]
 iron = "0.5.*"</code></pre>


### PR DESCRIPTION
As far as I am aware, iron and all the core iron crates work on Rust stable, so I removed what must be an outdated notice about Rust nightly.

Came up in a [reddit discussion](https://www.reddit.com/r/rust/comments/6rxjlt/iron_vs_rocket_performancebenchmarks/dl99u1y/).